### PR TITLE
fix: add Vercel domains to frame-ancestors CSP directive

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -70,7 +70,7 @@ app.use(helmet({
       imgSrc: ["'self'", "data:", "https:"],
       fontSrc: ["'self'", "data:"],
       connectSrc: ["'self'"],
-      frameAncestors: ["'self'", "http://localhost:3000", "https://localhost:3000"],
+      frameAncestors: ["'self'", "http://localhost:3000", "https://localhost:3000", "https://*.vercel.app"],
     },
   },
   hsts: process.env.NODE_ENV === 'production' ? {


### PR DESCRIPTION
- Allow iframe embedding from any Vercel deployment (*.vercel.app)
- Enables API documentation iframe to work in deployed frontend
- Maintains security while supporting production iframe functionality